### PR TITLE
feat: add statistics charts with dummy data

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-day-picker": "^9.8.1",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",
+    "recharts": "^2.12.0",
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.0.14"

--- a/src/app/statistics/page.tsx
+++ b/src/app/statistics/page.tsx
@@ -1,3 +1,8 @@
+import ProfitRateChart from '@/components/statistics/profit-rate-chart';
+import TimeHeatmap from '@/components/statistics/time-heatmap';
+import WinRateRatioChart from '@/components/statistics/win-rate-ratio-chart';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
 export default function StatisticsPage() {
   return (
     <div className="min-h-full bg-background">
@@ -8,14 +13,33 @@ export default function StatisticsPage() {
         </div>
       </div>
 
-      <div className="p-6">
-        <div className="rounded-lg border bg-card text-card-foreground shadow-sm p-8 text-center">
-          <div className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300 mb-4">
-            NEW
-          </div>
-          <h3 className="text-lg font-semibold mb-2">새로운 통계 기능</h3>
-          <p className="text-muted-foreground">고급 통계 분석 기능이 추가되었습니다!</p>
-        </div>
+      <div className="p-6 grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>수익률</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ProfitRateChart />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>승률 / 손익비</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <WinRateRatioChart />
+          </CardContent>
+        </Card>
+
+        <Card className="md:col-span-2">
+          <CardHeader>
+            <CardTitle>시간대별 히트맵</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <TimeHeatmap />
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/src/components/statistics/profit-rate-chart.tsx
+++ b/src/components/statistics/profit-rate-chart.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+const data = [
+  { date: '1/1', profit: 0.02 },
+  { date: '1/2', profit: -0.01 },
+  { date: '1/3', profit: 0.015 },
+  { date: '1/4', profit: 0.03 },
+  { date: '1/5', profit: -0.02 },
+  { date: '1/6', profit: 0.04 },
+];
+
+export default function ProfitRateChart() {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" />
+        <YAxis tickFormatter={(v) => `${(v * 100).toFixed(0)}%`} />
+        <Tooltip formatter={(value: number) => `${(value * 100).toFixed(2)}%`} />
+        <Line type="monotone" dataKey="profit" stroke="#8884d8" strokeWidth={2} />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/statistics/time-heatmap.tsx
+++ b/src/components/statistics/time-heatmap.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { ResponsiveContainer, ScatterChart, XAxis, YAxis, Tooltip, Scatter, Cell } from 'recharts';
+
+const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const hours = Array.from({ length: 24 }, (_, i) => i);
+
+const data = days.flatMap((day) =>
+  hours.map((hour) => ({
+    day,
+    hour,
+    value: Math.floor(Math.random() * 10),
+  }))
+);
+
+const getColor = (value: number) => {
+  if (value >= 7) return '#1e3a8a';
+  if (value >= 5) return '#3b82f6';
+  if (value >= 3) return '#93c5fd';
+  if (value > 0) return '#bfdbfe';
+  return '#e0f2fe';
+};
+
+export default function TimeHeatmap() {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+        <XAxis
+          type="number"
+          dataKey="hour"
+          name="Hour"
+          domain={[0, 23]}
+          ticks={[0, 6, 12, 18, 23]}
+        />
+        <YAxis type="category" dataKey="day" name="Day" />
+        <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+        <Scatter data={data} dataKey="value" shape="square">
+          {data.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={getColor(entry.value)} />
+          ))}
+        </Scatter>
+      </ScatterChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/statistics/win-rate-ratio-chart.tsx
+++ b/src/components/statistics/win-rate-ratio-chart.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+} from 'recharts';
+
+const winRateData = [
+  { name: 'Win', value: 65 },
+  { name: 'Loss', value: 35 },
+];
+
+const ratioData = [
+  { name: 'Profit', value: 150 },
+  { name: 'Loss', value: 100 },
+];
+
+const COLORS = ['#4ade80', '#f87171'];
+
+export default function WinRateRatioChart() {
+  return (
+    <div className="flex flex-col gap-6 md:flex-row">
+      <div className="flex-1">
+        <ResponsiveContainer width="100%" height={250}>
+          <PieChart>
+            <Pie
+              data={winRateData}
+              dataKey="value"
+              nameKey="name"
+              cx="50%"
+              cy="50%"
+              outerRadius={80}
+              label
+            >
+              {winRateData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="flex-1">
+        <ResponsiveContainer width="100%" height={250}>
+          <BarChart data={ratioData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="value">
+              {ratioData.map((entry, index) => (
+                <Cell key={`cell-bar-${index}`} fill={COLORS[index % COLORS.length]} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add recharts dependency
- implement profit rate, win rate/ratio, and time heatmap charts with dummy data
- integrate charts into statistics page layout

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f58d82dec8329bf414f2f11f9d4c6