### PR TITLE
Add Binance candle fetch, DB-backed trades, and scoring tests

### DIFF
--- a/trading-engine/README.md
+++ b/trading-engine/README.md
@@ -14,6 +14,16 @@ cd fastapi
 python main.py
 ```
 
+### 2. 데이터베이스 설정
+
+`DATABASE_URL` 환경 변수를 통해 PostgreSQL 연결을 설정합니다. 기본값은 `postgresql://localhost:5432/trading_journal` 입니다. 서버 시작 시 필요한 테이블이 자동으로 생성됩니다.
+
+### 3. 테스트 실행
+
+```bash
+pytest fastapi/tests
+```
+
 ### 2. Swagger UI 접속
 
 서버가 실행되면 다음 주소로 접속하세요:

--- a/trading-engine/app/database.py
+++ b/trading-engine/app/database.py
@@ -1,5 +1,5 @@
 # 데이터베이스 연결 및 스키마 정의
-from sqlalchemy import create_engine, Column, BigInteger, UUID, Date, Text, DateTime, Integer, ForeignKey, ARRAY
+from sqlalchemy import create_engine, Column, BigInteger, UUID, Date, Text, DateTime, Integer, Float, ForeignKey, ARRAY
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.dialects.postgresql import JSONB
@@ -37,6 +37,31 @@ class PatternHistory(Base):
     actions = Column(ARRAY(Text), nullable=True)
     summary_id = Column(BigInteger, ForeignKey("patterns_summary_weekly.id"))
     created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class TradeModel(Base):
+    """거래 기록 테이블"""
+    __tablename__ = "trades"
+
+    id = Column(BigInteger, primary_key=True, index=True)
+    symbol = Column(Text, nullable=False)
+    type = Column(Text, nullable=False)
+    trading_type = Column(Text, nullable=False)
+    quantity = Column(Float, nullable=False)
+    entry_price = Column(Float, nullable=False)
+    exit_price = Column(Float, nullable=True)
+    entry_time = Column(DateTime, nullable=False)
+    exit_time = Column(DateTime, nullable=True)
+    memo = Column(Text, nullable=True)
+    pnl = Column(Float, nullable=True)
+    status = Column(Text, nullable=False)
+    stop_loss = Column(Float, nullable=True)
+    indicators = Column(JSONB, nullable=True)
+    strategy_score = Column(JSONB, nullable=True)
+    forbidden_penalty = Column(Integer, nullable=True)
+    final_score = Column(Integer, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 # 테이블 생성
 def create_tables():

--- a/trading-engine/app/routes_trades.py
+++ b/trading-engine/app/routes_trades.py
@@ -1,23 +1,50 @@
-from fastapi import APIRouter, HTTPException, Query
-from typing import List
+from fastapi import APIRouter, HTTPException, Query, Depends
 from datetime import datetime
 from schemas import Trade, CreateTradeRequest, TradesResponse
 from scoring import compute_strategy_score, compute_forbidden_points
 from market_data import market_service
+from sqlalchemy.orm import Session
+from database import get_db, TradeModel
 
 router = APIRouter()
 
-# 임시 인메모리 저장
-TRADES: List[Trade] = []
-
 @router.get('/trades', response_model=TradesResponse)
-def list_trades(limit: int = Query(10, ge=1, le=100), offset: int = Query(0, ge=0)):
-    ordered = sorted(TRADES, key=lambda t: t.entryTime, reverse=True)
-    page = ordered[offset: offset + limit]
-    return TradesResponse(trades=page, total=len(ordered), page=(offset // limit) + 1, limit=limit)
+def list_trades(
+    limit: int = Query(10, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+):
+    query = db.query(TradeModel).order_by(TradeModel.entry_time.desc())
+    total = query.count()
+    records = query.offset(offset).limit(limit).all()
+    trades = [
+        Trade(
+            id=str(t.id),
+            symbol=t.symbol,
+            type=t.type,
+            tradingType=t.trading_type,
+            quantity=t.quantity,
+            entryPrice=t.entry_price,
+            exitPrice=t.exit_price,
+            entryTime=t.entry_time,
+            exitTime=t.exit_time,
+            memo=t.memo,
+            pnl=t.pnl,
+            status=t.status,
+            stopLoss=t.stop_loss,
+            indicators=t.indicators,
+            strategyScore=t.strategy_score,
+            forbiddenPenalty=t.forbidden_penalty,
+            finalScore=t.final_score,
+            createdAt=t.created_at,
+            updatedAt=t.updated_at,
+        )
+        for t in records
+    ]
+    return TradesResponse(trades=trades, total=total, page=(offset // limit) + 1, limit=limit)
 
 @router.post('/trades', response_model=Trade, status_code=201)
-def create_trade(req: CreateTradeRequest):
+def create_trade(req: CreateTradeRequest, db: Session = Depends(get_db)):
     """거래 생성 및 스코어링 (자동 차트 데이터 연동)"""
     # 심볼 유효성 검사
     if not market_service.validate_symbol(req.symbol):
@@ -42,7 +69,11 @@ def create_trade(req: CreateTradeRequest):
     # 간단 손익 계산
     pnl = None
     if req.exitPrice is not None:
-        pnl = (req.exitPrice - req.entryPrice) * req.quantity if req.type == 'buy' else (req.entryPrice - req.exitPrice) * req.quantity
+        pnl = (
+            (req.exitPrice - req.entryPrice) * req.quantity
+            if req.type == 'buy'
+            else (req.entryPrice - req.exitPrice) * req.quantity
+        )
 
     trade = Trade(
         id=str(int(datetime.utcnow().timestamp() * 1000)),
@@ -58,12 +89,11 @@ def create_trade(req: CreateTradeRequest):
         pnl=pnl,
         status='closed' if req.exitPrice is not None else 'open',
         stopLoss=req.stopLoss,
-        indicators=final_indicators,  # 병합된 indicators 사용
+        indicators=final_indicators,
         createdAt=datetime.utcnow(),
         updatedAt=datetime.utcnow(),
     )
 
-    # 전략 60점 + 금기룰 40점
     strategy = compute_strategy_score(trade)
     if strategy:
         trade.strategyScore = strategy
@@ -72,5 +102,27 @@ def create_trade(req: CreateTradeRequest):
     base = strategy.totalScore if strategy else 0
     trade.finalScore = base + forbidden_points
 
-    TRADES.insert(0, trade)
+    db_trade = TradeModel(
+        id=int(trade.id),
+        symbol=trade.symbol,
+        type=trade.type,
+        trading_type=trade.tradingType,
+        quantity=trade.quantity,
+        entry_price=trade.entryPrice,
+        exit_price=trade.exitPrice,
+        entry_time=trade.entryTime,
+        exit_time=trade.exitTime,
+        memo=trade.memo,
+        pnl=trade.pnl,
+        status=trade.status,
+        stop_loss=trade.stopLoss,
+        indicators=trade.indicators.dict() if trade.indicators else None,
+        strategy_score=trade.strategyScore.dict() if trade.strategyScore else None,
+        forbidden_penalty=trade.forbiddenPenalty,
+        final_score=trade.finalScore,
+        created_at=trade.createdAt,
+        updated_at=trade.updatedAt,
+    )
+    db.add(db_trade)
+    db.commit()
     return trade

--- a/trading-engine/fastapi/tests/test_scores.py
+++ b/trading-engine/fastapi/tests/test_scores.py
@@ -1,0 +1,73 @@
+import os
+import sys
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure imports work when running tests from repo root
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import main
+from models import Candle, TimeframeEnum
+
+
+@pytest.fixture(autouse=True)
+def mock_candles(monkeypatch):
+    async def _fake_get_candles(trade_data):
+        return [
+            Candle(
+                timestamp=1,
+                open=1.0,
+                high=1.0,
+                low=1.0,
+                close=1.0,
+                volume=1.0,
+                symbol=trade_data["pair"],
+                timeframe=TimeframeEnum.FIVE_MINUTES,
+            )
+            for _ in range(20)
+        ]
+
+    monkeypatch.setattr(main, "_get_candles_for_trade", _fake_get_candles)
+
+
+@pytest.fixture
+def client():
+    return TestClient(main.app)
+
+
+def _sample_trade():
+    return {
+        "pair": "BTC/USDT",
+        "side": "buy",
+        "amount": 1.0,
+        "price": 100.0,
+        "timestamp": datetime.utcnow().isoformat(),
+        "strategy": "test",
+        "confidence": 0.5,
+        "stop_loss": 90.0,
+        "take_profit": 110.0,
+        "metadata": {}
+    }
+
+
+def test_breakout_endpoint(client):
+    resp = client.post("/api/v1/trade/breakout", json=_sample_trade())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "total_score" in body
+
+
+def test_trend_endpoint(client):
+    resp = client.post("/api/v1/trade/trend", json=_sample_trade())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "total_score" in body
+
+
+def test_mean_reversion_endpoint(client):
+    resp = client.post("/api/v1/trade/mean_reversion", json=_sample_trade())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "total_score" in body


### PR DESCRIPTION
## Summary
- Fetch real candles from Binance in `_get_candles_for_trade`
- Persist trades to PostgreSQL via new `TradeModel` and updated routes
- Import trade and pattern routers into main FastAPI app for unified API
- Add pytest-based tests for breakout, trend, and mean reversion endpoints
- Document DB configuration and test execution

## Testing
- `pytest tests/test_scores.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6898ebada3208329861f5acfb537ab6a