### PR TITLE
Handle duplicate emails during OAuth2 login

### DIFF
--- a/backend/src/main/java/com/example/trading_bot/auth/entity/User.java
+++ b/backend/src/main/java/com/example/trading_bot/auth/entity/User.java
@@ -78,4 +78,10 @@ public class User extends BaseTimeEntity {
             this.profileImageUrl = profileImageUrl;
         }
     }
+
+    // OAuth2 제공자 정보 연결 (이메일 중복 사용자 처리용)
+    public void linkProvider(ProviderType providerType, String providerId) {
+        this.providerType = providerType;
+        this.providerId = providerId;
+    }
 }

--- a/backend/src/main/java/com/example/trading_bot/auth/service/AuthService.java
+++ b/backend/src/main/java/com/example/trading_bot/auth/service/AuthService.java
@@ -94,7 +94,9 @@ public class AuthService {
 
         User user = existingUser
                 .map(u -> updateOAuth2UserProfile(u, name, profileImageUrl))
-                .orElseGet(() -> createOAuth2User(email, name, profileImageUrl, providerType, providerId));
+                .orElseGet(() -> userRepository.findByEmail(email)
+                        .map(u -> linkOAuth2User(u, name, profileImageUrl, providerType, providerId))
+                        .orElseGet(() -> createOAuth2User(email, name, profileImageUrl, providerType, providerId)));
 
         return generateTokenResponse(user);
     }
@@ -139,6 +141,13 @@ public class AuthService {
 
     private User updateOAuth2UserProfile(User user, String name, String profileImageUrl) {
         user.updateProfile(name, profileImageUrl);
+        return userRepository.save(user);
+    }
+
+    private User linkOAuth2User(User user, String name, String profileImageUrl,
+                                ProviderType providerType, String providerId) {
+        user.updateProfile(name, profileImageUrl);
+        user.linkProvider(providerType, providerId);
         return userRepository.save(user);
     }
 


### PR DESCRIPTION
## Summary
- Link existing users with OAuth2 providers to prevent duplicate email constraint violations
- Allow updating user profiles when federated login uses an existing email

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_689ca96364b08329b3560395c45d0e7d