### PR TITLE
fix: remove external font dependency and stabilize auth callback

### DIFF
--- a/frontend/src/app/auth/google/callback/page.tsx
+++ b/frontend/src/app/auth/google/callback/page.tsx
@@ -1,15 +1,13 @@
 'use client';
 
-import { useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
-import { useAuth } from '@/components/providers/auth-provider';
 import { authStorage } from '@/lib/auth-storage';
 
-export default function GoogleCallbackPage() {
+function GoogleCallbackContent() {
   const params = useSearchParams();
   const router = useRouter();
-  const { oauth2Login } = useAuth();
 
   useEffect(() => {
     const code = params.get('code');
@@ -49,7 +47,7 @@ export default function GoogleCallbackPage() {
         router.replace('/login');
       }
     })();
-  }, [params, router, oauth2Login]);
+  }, [params, router]);
 
   return (
     <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center p-6">
@@ -57,6 +55,14 @@ export default function GoogleCallbackPage() {
         구글 로그인 처리 중...
       </div>
     </div>
+  );
+}
+
+export default function GoogleCallbackPage() {
+  return (
+    <Suspense>
+      <GoogleCallbackContent />
+    </Suspense>
   );
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6,8 +6,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: ui-sans-serif, system-ui, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,20 +1,9 @@
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { QueryProvider } from '@/components/providers/query-provider';
 import { ThemeProvider } from '@/components/providers/theme-provider';
 import { ToastProvider } from '@/components/providers/toast-provider';
 import { MainLayout } from '@/components/layout/main-layout';
-
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
-});
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-});
 
 export const metadata: Metadata = {
   title: '코인 트레이딩 저널',
@@ -28,7 +17,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko" suppressHydrationWarning>
-      <body suppressHydrationWarning className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body suppressHydrationWarning className="antialiased">
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/frontend/src/components/providers/auth-provider.tsx
+++ b/frontend/src/components/providers/auth-provider.tsx
@@ -47,7 +47,7 @@ function setupAxiosInterceptors() {
           original.headers = original.headers ?? {};
           original.headers.Authorization = `Bearer ${tokens.accessToken}`;
           return apiClient(original);
-        } catch (e) {
+        } catch {
           authStorage.clear();
         }
       }


### PR DESCRIPTION
## Summary
- drop remote Google fonts and rely on system fonts to allow offline builds
- handle token refresh without unused variable warning
- wrap Google OAuth callback in Suspense to satisfy Next.js requirements

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`
- `bash ./gradlew test` (fails: Unable to tunnel through proxy 403)


------
https://chatgpt.com/codex/tasks/task_e_689dca290f308329b454895bc9065545