### PR TITLE
feat: allow configurable minimum training samples

### DIFF
--- a/nautilus-ml-pipeline/config/ml_config.yaml
+++ b/nautilus-ml-pipeline/config/ml_config.yaml
@@ -8,6 +8,7 @@ data:
     - market_condition
     - volume_profile
   target: return_pct
+  min_samples: 5
   validation:
     min_train_size: 100
     test_size: 0.2

--- a/nautilus-ml-pipeline/main_pipeline.py
+++ b/nautilus-ml-pipeline/main_pipeline.py
@@ -181,6 +181,10 @@ class IntegratedMLPipeline:
     
     async def _update_performance_history(self, metrics: dict):
         """성능 히스토리 업데이트"""
+        if metrics.get('status') == 'insufficient_samples':
+            logger.info("데이터 부족으로 성능 히스토리 업데이트를 스킵합니다")
+            return
+
         self.scheduler.update_performance_history(metrics)
         self.scheduler.mark_retrain_completed()
         


### PR DESCRIPTION
## Summary
- make minimum training sample size configurable via `ml_config.yaml`
- warn and retry data collection via callback when samples are insufficient
- surface error status instead of placeholder metrics and skip performance history update

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests httpx` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0873787588329a8c3ee3cdd5d6a8b