### PR TITLE
chore: enforce price column defaults

### DIFF
--- a/nautilus-ml-pipeline/database_manager.py
+++ b/nautilus-ml-pipeline/database_manager.py
@@ -164,7 +164,10 @@ class BacktestDatabaseManager:
             
             # 집계 통계 계산
             total_trades = int(len(df))
-            total_pnl = float(df['pnl'].sum()) if 'pnl' in df.columns else 0.0
+            if 'pnl' in df.columns:
+                total_pnl = float(round(df['pnl'].fillna(0).sum(), 6))
+            else:
+                total_pnl = 0.0
             if 'pnl' in df.columns and len(df['pnl']) > 0:
                 wr = (df['pnl'] > 0).mean()
                 win_rate = float(wr) if pd.notna(wr) else 0.0
@@ -219,7 +222,13 @@ class BacktestDatabaseManager:
                 # 개별 거래 데이터 저장 (배치 처리)
                 df_copy = df.copy()
                 df_copy['backtest_run_id'] = backtest_run_id
-                
+
+                # 가격 및 손익 컬럼 기본값/정밀도 처리
+                numeric_cols = ['entry_price', 'stop_loss', 'take_profit', 'exit_price', 'pnl']
+                for col in numeric_cols:
+                    if col in df_copy.columns:
+                        df_copy[col] = df_copy[col].fillna(0).round(6)
+
                 # 컬럼 매핑 및 타입 변환
                 column_mapping = {
                     'timestamp': 'timestamp',

--- a/nautilus-ml-pipeline/database_setup.sql
+++ b/nautilus-ml-pipeline/database_setup.sql
@@ -9,8 +9,8 @@ CREATE TABLE IF NOT EXISTS backtest_runs (
     start_date TIMESTAMP NOT NULL, -- 백테스트 시작 일시
     end_date TIMESTAMP NOT NULL, -- 백테스트 종료 일시
     timeframe VARCHAR(10) NOT NULL, -- 시간프레임 (1m, 5m, 1h 등)
-    total_trades INTEGER DEFAULT 0, -- 총 거래 수
-    total_pnl DECIMAL(15,8) DEFAULT 0, -- 총 손익
+    total_trades INTEGER NOT NULL DEFAULT 0, -- 총 거래 수
+    total_pnl DECIMAL(12,6) NOT NULL DEFAULT 0, -- 총 손익
     win_rate DECIMAL(5,4) DEFAULT 0, -- 승률 (0.0 ~ 1.0)
     max_drawdown DECIMAL(8,4) DEFAULT 0, -- 최대 손실폭 (범위 확장)
     sharpe_ratio DECIMAL(8,4) DEFAULT 0, -- 샤프 비율
@@ -32,9 +32,9 @@ CREATE TABLE IF NOT EXISTS backtest_trades (
     strategy_type VARCHAR(50) NOT NULL, -- 전략 유형
     
     -- 진입 정보
-    entry_price DECIMAL(15,8) NOT NULL, -- 진입 가격
-    stop_loss DECIMAL(15,8), -- 손절가
-    take_profit DECIMAL(15,8), -- 익절가
+    entry_price DECIMAL(12,6) NOT NULL, -- 진입 가격
+    stop_loss DECIMAL(12,6) NOT NULL DEFAULT 0, -- 손절가
+    take_profit DECIMAL(12,6) NOT NULL DEFAULT 0, -- 익절가
     
     -- 전략 점수 및 신뢰도
     strategy_score DECIMAL(5,2), -- 전략 점수 (0-100)
@@ -42,12 +42,12 @@ CREATE TABLE IF NOT EXISTS backtest_trades (
     risk_level VARCHAR(20), -- 위험 수준 (low, medium, high)
     
     -- 청산 정보
-    exit_price DECIMAL(15,8), -- 청산 가격
+    exit_price DECIMAL(12,6) NOT NULL DEFAULT 0, -- 청산 가격
     exit_timestamp TIMESTAMP, -- 청산 일시
     exit_reason VARCHAR(50), -- 청산 사유 (take_profit, stop_loss, timeout)
     
     -- 성과 지표
-    pnl DECIMAL(15,8), -- 손익 (절대값)
+    pnl DECIMAL(12,6) NOT NULL DEFAULT 0, -- 손익 (절대값)
     return_pct DECIMAL(8,4), -- 수익률 (%)
     duration_minutes INTEGER, -- 거래 지속 시간 (분)
     

--- a/nautilus-ml-pipeline/migrations/001_adjust_precision_and_defaults.sql
+++ b/nautilus-ml-pipeline/migrations/001_adjust_precision_and_defaults.sql
@@ -1,0 +1,33 @@
+-- Migration: adjust precision and enforce defaults on price/PnL columns
+
+-- backtest_runs updates
+UPDATE backtest_runs SET total_trades = 0 WHERE total_trades IS NULL;
+UPDATE backtest_runs SET total_pnl = 0 WHERE total_pnl IS NULL;
+
+ALTER TABLE backtest_runs
+    ALTER COLUMN total_trades SET DEFAULT 0,
+    ALTER COLUMN total_trades SET NOT NULL,
+    ALTER COLUMN total_pnl TYPE DECIMAL(12,6) USING ROUND(total_pnl::numeric, 6),
+    ALTER COLUMN total_pnl SET DEFAULT 0,
+    ALTER COLUMN total_pnl SET NOT NULL;
+
+-- backtest_trades updates
+UPDATE backtest_trades SET stop_loss = 0 WHERE stop_loss IS NULL;
+UPDATE backtest_trades SET take_profit = 0 WHERE take_profit IS NULL;
+UPDATE backtest_trades SET exit_price = 0 WHERE exit_price IS NULL;
+UPDATE backtest_trades SET pnl = 0 WHERE pnl IS NULL;
+
+ALTER TABLE backtest_trades
+    ALTER COLUMN entry_price TYPE DECIMAL(12,6) USING ROUND(entry_price::numeric, 6),
+    ALTER COLUMN stop_loss TYPE DECIMAL(12,6) USING ROUND(stop_loss::numeric, 6),
+    ALTER COLUMN take_profit TYPE DECIMAL(12,6) USING ROUND(take_profit::numeric, 6),
+    ALTER COLUMN exit_price TYPE DECIMAL(12,6) USING ROUND(exit_price::numeric, 6),
+    ALTER COLUMN pnl TYPE DECIMAL(12,6) USING ROUND(pnl::numeric, 6),
+    ALTER COLUMN stop_loss SET DEFAULT 0,
+    ALTER COLUMN take_profit SET DEFAULT 0,
+    ALTER COLUMN exit_price SET DEFAULT 0,
+    ALTER COLUMN pnl SET DEFAULT 0,
+    ALTER COLUMN stop_loss SET NOT NULL,
+    ALTER COLUMN take_profit SET NOT NULL,
+    ALTER COLUMN exit_price SET NOT NULL,
+    ALTER COLUMN pnl SET NOT NULL;


### PR DESCRIPTION
## Summary
- ensure core price fields use DECIMAL(12,6) with NOT NULL defaults
- add migration for existing data to adopt new precision and defaults
- round and fill price values when saving backtest trades

## Testing
- `pytest nautilus-ml-pipeline/test_simple_performance.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests httpx` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_68a08749352c832993544f3838a93380