### PR TITLE
Harden admin dashboard security

### DIFF
--- a/frontend/src/components/statistics/profit-rate-chart.tsx
+++ b/frontend/src/components/statistics/profit-rate-chart.tsx
@@ -32,11 +32,12 @@ export default function ProfitRateChart() {
 
   useEffect(() => {
     const controller = new AbortController();
-    const url = `${MONITORING_API_BASE.replace(/\/$/, '')}/api/pnl_history_public?token=${encodeURIComponent(
-      PUBLIC_TOKEN
-    )}&days=30`;
+    const url = `${MONITORING_API_BASE.replace(/\/$/, '')}/api/pnl_history_public?days=30`;
 
-    fetch(url, { signal: controller.signal })
+    fetch(url, {
+      signal: controller.signal,
+      headers: { 'X-API-KEY': PUBLIC_TOKEN },
+    })
       .then(async (r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         const data: PnlApiResponse = await r.json();

--- a/nautilus-ml-pipeline/README_monitoring.md
+++ b/nautilus-ml-pipeline/README_monitoring.md
@@ -55,7 +55,6 @@ python start_monitoring.py --mode prod --host 0.0.0.0 --port 5001
 ### 3. 접속
 
 - **URL**: http://localhost:5001
-- **기본 계정**: admin / admin123
 
 ## 📊 API 엔드포인트
 
@@ -83,8 +82,10 @@ python start_monitoring.py --mode prod --host 0.0.0.0 --port 5001
 
 ```bash
 export FLASK_SECRET_KEY="your-secret-key-here"
-export ADMIN_USERNAME="admin"
+export ADMIN_USERNAME="your-admin"
 export ADMIN_PASSWORD_HASH="sha256-hash-of-password"
+export PUBLIC_API_TOKEN="random-readonly-token"
+export CORS_ALLOWED_ORIGINS="http://localhost,http://127.0.0.1"
 ```
 
 ### 비밀번호 변경
@@ -95,6 +96,10 @@ new_password = "your_new_password"
 password_hash = hashlib.sha256(new_password.encode()).hexdigest()
 # ADMIN_PASSWORD_HASH 환경 변수에 설정
 ```
+
+### 공개 API 사용
+
+`/api/pnl_history_public` 호출 시 `X-API-KEY` 헤더에 `PUBLIC_API_TOKEN` 값을 포함해야 합니다.
 
 ## 📱 UI 특징
 

--- a/nautilus-ml-pipeline/ml_monitoring_frontend/requirements.txt
+++ b/nautilus-ml-pipeline/ml_monitoring_frontend/requirements.txt
@@ -1,6 +1,8 @@
 Flask==3.0.0
 Flask-Login==0.6.3
 Flask-Cors==4.0.0
+Flask-WTF==1.2.1
+Flask-Limiter==3.5.0
 Werkzeug==3.0.1
 Jinja2==3.1.2
 itsdangerous==2.1.2

--- a/nautilus-ml-pipeline/ml_monitoring_frontend/start_monitoring.py
+++ b/nautilus-ml-pipeline/ml_monitoring_frontend/start_monitoring.py
@@ -13,18 +13,22 @@ from pathlib import Path
 
 def setup_environment():
     """환경 변수 설정"""
-    # 한글 주석: 기본 환경 변수 설정
+    # 한글 주석: 필수 환경 변수 확인
     os.environ.setdefault('FLASK_SECRET_KEY', 'ml-monitoring-secret-2025-trading-system')
-    os.environ.setdefault('ADMIN_USERNAME', 'admin')
-    
-    # 한글 주석: 기본 비밀번호 해시 (admin123)
+    required = ['ADMIN_USERNAME', 'ADMIN_PASSWORD_HASH', 'PUBLIC_API_TOKEN']
+
+    missing = [v for v in required if not os.environ.get(v)]
+    if missing:
+        raise RuntimeError(f"필수 환경 변수가 설정되지 않았습니다: {', '.join(missing)}")
+
     import hashlib
-    default_password_hash = hashlib.sha256('admin123'.encode()).hexdigest()
-    os.environ.setdefault('ADMIN_PASSWORD_HASH', default_password_hash)
-    
-    print("환경 변수 설정 완료")
+    if os.environ['ADMIN_PASSWORD_HASH'] == hashlib.sha256('admin123'.encode()).hexdigest():
+        raise RuntimeError('기본 관리자 비밀번호(admin123)를 변경해야 합니다.')
+
+    os.environ.setdefault('CORS_ALLOWED_ORIGINS', 'http://localhost,http://127.0.0.1')
+
+    print("환경 변수 확인 완료")
     print(f"관리자 계정: {os.environ['ADMIN_USERNAME']}")
-    print("기본 비밀번호: admin123 (보안을 위해 변경 권장)")
 
 def main():
     parser = argparse.ArgumentParser(description='ML 성능 모니터링 대시보드')
@@ -48,7 +52,7 @@ def main():
         print(f"{'='*60}")
         print(f"모드: {args.mode}")
         print(f"주소: http://{args.host}:{args.port}")
-        print(f"관리자 계정: {os.environ['ADMIN_USERNAME']} / admin123")
+        print(f"관리자 계정: {os.environ['ADMIN_USERNAME']}")
         print(f"{'='*60}\n")
         
         if args.mode == 'dev':

--- a/nautilus-ml-pipeline/ml_monitoring_frontend/templates/login.html
+++ b/nautilus-ml-pipeline/ml_monitoring_frontend/templates/login.html
@@ -15,6 +15,7 @@ endblock %} {% block content %}
           </div>
 
           <form method="POST">
+            {{ csrf_token() }}
             <div class="mb-3">
               <label for="username" class="form-label">
                 <i class="fas fa-user me-1"></i>사용자명
@@ -57,12 +58,12 @@ endblock %} {% block content %}
             </small>
           </div>
 
-          <!-- 개발 환경에서만 표시 -->
+          <!-- 개발 환경 안내 -->
           {% if config.DEBUG %}
           <div class="alert alert-info mt-3" role="alert">
             <small>
               <strong>개발 모드:</strong><br />
-              기본 계정: admin / admin123
+              환경 변수로 설정한 관리자 계정을 사용하세요.
             </small>
           </div>
           {% endif %}


### PR DESCRIPTION
## Summary
- Restrict admin account credentials to environment variables and enforce password change
- Limit CORS origins, enable CSRF protection, and rate limit APIs
- Require API key header for public PnL endpoint and document new environment settings

## Testing
- `python -m py_compile nautilus-ml-pipeline/ml_monitoring_frontend/app.py nautilus-ml-pipeline/ml_monitoring_frontend/start_monitoring.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm test` *(fails: Missing script: "test")*
- `pip install Flask-WTF==1.2.1 Flask-Limiter==3.5.0` *(fails: Could not find a version that satisfies the requirement Flask-WTF==1.2.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a079dcfaf083299cd6830d563761b7