### PR TITLE
feat: add trade editing and deletion UI

### DIFF
--- a/frontend/src/app/api/trades/[id]/route.ts
+++ b/frontend/src/app/api/trades/[id]/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { trades, calculatePnL } from '../data';
+import { createTradeSchema } from '@/schemas/trade';
+import { z } from 'zod';
+import {
+  computeStrategyScore,
+  computeForbiddenPoints,
+  TOTAL_FORBIDDEN_POINTS,
+} from '@/lib/strategy-scoring';
+
+const BACKEND_BASE_URL = process.env.BACKEND_BASE_URL;
+
+// 개별 거래 수정
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const body = await request.json();
+    const validatedData = createTradeSchema.partial().parse(body);
+
+    if (BACKEND_BASE_URL) {
+      try {
+        const url = `${BACKEND_BASE_URL.replace(/\/$/, '')}/trades/${params.id}`;
+        const resp = await fetch(url, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(validatedData),
+        });
+        if (resp.ok) {
+          const data = await resp.json();
+          return NextResponse.json(data, { status: resp.status });
+        }
+        console.warn(
+          `BACKEND proxy PUT /trades/${params.id} failed with status ${resp.status}. Falling back to local.`
+        );
+      } catch (err) {
+        console.warn('BACKEND proxy PUT /trades error. Falling back to local.', err);
+      }
+    }
+
+    const index = trades.findIndex((t) => t.id === params.id);
+    if (index === -1)
+      return NextResponse.json({ error: 'Trade not found' }, { status: 404 });
+
+    const existing = trades[index];
+    const updated = {
+      ...existing,
+      ...validatedData,
+      entryTime: validatedData.entryTime
+        ? new Date(validatedData.entryTime)
+        : existing.entryTime,
+      exitTime: validatedData.exitTime
+        ? new Date(validatedData.exitTime)
+        : existing.exitTime,
+      updatedAt: new Date(),
+    };
+
+    updated.pnl = calculatePnL(updated);
+    updated.status = updated.exitPrice ? 'closed' : existing.status;
+
+    const strategyScore = computeStrategyScore(updated, updated.indicators);
+    if (strategyScore) updated.strategyScore = strategyScore;
+    const forbiddenPoints = computeForbiddenPoints(updated, trades, 100000);
+    updated.forbiddenPenalty = TOTAL_FORBIDDEN_POINTS - forbiddenPoints;
+    const base = strategyScore?.totalScore ?? 0;
+    updated.finalScore = base + forbiddenPoints;
+
+    trades[index] = updated;
+    return NextResponse.json(updated);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: '입력값이 올바르지 않습니다', details: error.issues },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json(
+      { error: '거래 수정에 실패했습니다' },
+      { status: 500 }
+    );
+  }
+}
+
+// 개별 거래 삭제
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    if (BACKEND_BASE_URL) {
+      try {
+        const url = `${BACKEND_BASE_URL.replace(/\/$/, '')}/trades/${params.id}`;
+        const resp = await fetch(url, { method: 'DELETE' });
+        if (resp.ok) {
+          return NextResponse.json(null, { status: resp.status });
+        }
+        console.warn(
+          `BACKEND proxy DELETE /trades/${params.id} failed with status ${resp.status}. Falling back to local.`
+        );
+      } catch (err) {
+        console.warn('BACKEND proxy DELETE /trades error. Falling back to local.', err);
+      }
+    }
+
+    const index = trades.findIndex((t) => t.id === params.id);
+    if (index === -1)
+      return NextResponse.json({ error: 'Trade not found' }, { status: 404 });
+
+    trades.splice(index, 1);
+    return NextResponse.json(null);
+  } catch (error) {
+    return NextResponse.json(
+      { error: '거래 삭제에 실패했습니다' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/trades/data.ts
+++ b/frontend/src/app/api/trades/data.ts
@@ -1,0 +1,59 @@
+import { Trade } from '@/types/trade';
+
+// 임시 메모리 저장소 (실제 프로젝트에서는 데이터베이스 사용)
+// eslint-disable-next-line prefer-const
+export let trades: Trade[] = [
+  {
+    id: '1',
+    symbol: 'BTC/USDT',
+    type: 'buy',
+    tradingType: 'trend',
+    quantity: 0.5,
+    entryPrice: 45000,
+    exitPrice: 47000,
+    entryTime: new Date('2024-01-15T10:30:00'),
+    exitTime: new Date('2024-01-16T14:20:00'),
+    memo: '상승 추세 진입',
+    pnl: 1000,
+    status: 'closed',
+    createdAt: new Date('2024-01-15T10:30:00'),
+    updatedAt: new Date('2024-01-16T14:20:00'),
+  },
+  {
+    id: '2',
+    symbol: 'ETH/USDT',
+    type: 'buy',
+    tradingType: 'breakout',
+    quantity: 2.0,
+    entryPrice: 2800,
+    entryTime: new Date('2024-01-20T09:15:00'),
+    memo: '지지선 반등 기대',
+    status: 'open',
+    createdAt: new Date('2024-01-20T09:15:00'),
+    updatedAt: new Date('2024-01-20T09:15:00'),
+  },
+  {
+    id: '3',
+    symbol: 'SOL/USDT',
+    type: 'sell',
+    tradingType: 'counter_trend',
+    quantity: 10,
+    entryPrice: 120,
+    exitPrice: 115,
+    entryTime: new Date('2024-01-18T16:45:00'),
+    exitTime: new Date('2024-01-19T11:30:00'),
+    memo: '과매수 구간 진입으로 숏 포지션',
+    pnl: -50,
+    status: 'closed',
+    createdAt: new Date('2024-01-18T16:45:00'),
+    updatedAt: new Date('2024-01-19T11:30:00'),
+  },
+];
+
+// 손익 계산 함수
+export function calculatePnL(trade: Omit<Trade, 'pnl'>): number {
+  if (!trade.exitPrice) return 0;
+  return trade.type === 'buy'
+    ? (trade.exitPrice - trade.entryPrice) * trade.quantity
+    : (trade.entryPrice - trade.exitPrice) * trade.quantity;
+}

--- a/frontend/src/app/api/trades/route.ts
+++ b/frontend/src/app/api/trades/route.ts
@@ -1,72 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createTradeSchema } from '@/schemas/trade';
-import { Trade } from '@/types/trade';
 import { z } from 'zod';
 import {
   computeStrategyScore,
   computeForbiddenPoints,
   TOTAL_FORBIDDEN_POINTS,
 } from '@/lib/strategy-scoring';
+import { trades, calculatePnL } from './data';
 
 const BACKEND_BASE_URL = process.env.BACKEND_BASE_URL; // e.g. http://localhost:8000
-
-// 임시 메모리 저장소 (실제 프로젝트에서는 데이터베이스 사용)
-// eslint-disable-next-line prefer-const
-let trades: Trade[] = [
-  {
-    id: '1',
-    symbol: 'BTC/USDT',
-    type: 'buy',
-    tradingType: 'trend',
-    quantity: 0.5,
-    entryPrice: 45000,
-    exitPrice: 47000,
-    entryTime: new Date('2024-01-15T10:30:00'),
-    exitTime: new Date('2024-01-16T14:20:00'),
-    memo: '상승 추세 진입',
-    pnl: 1000,
-    status: 'closed',
-    createdAt: new Date('2024-01-15T10:30:00'),
-    updatedAt: new Date('2024-01-16T14:20:00'),
-  },
-  {
-    id: '2',
-    symbol: 'ETH/USDT',
-    type: 'buy',
-    tradingType: 'breakout',
-    quantity: 2.0,
-    entryPrice: 2800,
-    entryTime: new Date('2024-01-20T09:15:00'),
-    memo: '지지선 반등 기대',
-    status: 'open',
-    createdAt: new Date('2024-01-20T09:15:00'),
-    updatedAt: new Date('2024-01-20T09:15:00'),
-  },
-  {
-    id: '3',
-    symbol: 'SOL/USDT',
-    type: 'sell',
-    tradingType: 'counter_trend',
-    quantity: 10,
-    entryPrice: 120,
-    exitPrice: 115,
-    entryTime: new Date('2024-01-18T16:45:00'),
-    exitTime: new Date('2024-01-19T11:30:00'),
-    memo: '과매수 구간 진입으로 숏 포지션',
-    pnl: -50,
-    status: 'closed',
-    createdAt: new Date('2024-01-18T16:45:00'),
-    updatedAt: new Date('2024-01-19T11:30:00'),
-  },
-];
-
-// 손익 계산 함수
-function calculatePnL(trade: Omit<Trade, 'pnl'>): number {
-  if (!trade.exitPrice) return 0;
-  return trade.type === 'buy'
-    ? (trade.exitPrice - trade.entryPrice) * trade.quantity
-    : (trade.entryPrice - trade.exitPrice) * trade.quantity;
-}
 
 // GET /api/trades - 거래 목록 조회
 export async function GET(request: NextRequest) {


### PR DESCRIPTION
## Summary
- support editing trades in TradeForm and display appropriate UI labels
- add edit/delete actions and dialog state handling in TradesTable
- expose PUT/DELETE trade API routes with local fallback storage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: auto-trading/page.tsx - 'Pause' is defined but never used)*
- `npm run type-check` *(fails: tsc --noEmit)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b56c5d60832992b1c5f09f9241e7